### PR TITLE
feat: support generic RemoveEventListener syntax

### DIFF
--- a/src/node-events-listener.js
+++ b/src/node-events-listener.js
@@ -41,7 +41,13 @@ HTMLElement.prototype.addEventListener = function(name, callback, ...props) {
   return listenerId
 }
 
-HTMLElement.prototype.removeEventListener = function(listenerId) {
+HTMLElement.prototype.removeEventListener = function(listenerId, ...props) {
+  // More than one prop were passed. It means that user is trying
+  // to call the original removeEventListener
+  if(props.length) {
+    return GENERIC_FUNCTIONS.removeEventListener.call(this, ...arguments)
+  }
+
   // Removes listener id from the cache
   // and retrieves cached listener information
   const {eventName, callback} = clearListener(listenerId)


### PR DESCRIPTION
Gives the ability to use the next syntax:
`.removeEventListener(eventName, callback)`

Since this syntax is generic, it's important to support it to avoid confusion. The problem is solved by adding an overload to the removeEventListener function. Now we have both those overloads :

`.removeEventListener(eventName, callback)`
*and*
`.removeEventListener(listenerId)`